### PR TITLE
Fixed a typo at simulation.py

### DIFF
--- a/simulation.py
+++ b/simulation.py
@@ -198,7 +198,7 @@ class GenData(object):
             elif self.gens == 'xy':
                 self.su_2n_delta = self.su_2n[1::]
             elif self.gens == 'xz':
-                self.su_2n_dela = [gentest.su_2n[0],gentest.su_2n[2]]
+                self.su_2n_delta = [gentest.su_2n[0],gentest.su_2n[2]]
         
         elif self.su_dim == 2:
             self.twobod = rn.sample(list(self.su_2n[6::]),1)[0]

--- a/simulation.py
+++ b/simulation.py
@@ -198,7 +198,7 @@ class GenData(object):
             elif self.gens == 'xy':
                 self.su_2n_delta = self.su_2n[1::]
             elif self.gens == 'xz':
-                self.su_2n_delta = [gentest.su_2n[0],gentest.su_2n[2]]
+                self.su_2n_delta = [self.su_2n[0],self.su_2n[2]]
         
         elif self.su_dim == 2:
             self.twobod = rn.sample(list(self.su_2n[6::]),1)[0]


### PR DESCRIPTION
At the file `simulation.py`, in the method `su2ndelta`, there was a typo when user inputs gens = "xz".  This could be problematic when generating unitaries for training.

It also seems that the code calls some sort of gentest, not present in `simulation.py` itself. By pattern, I am guessing you meant to write self.

Kudos,